### PR TITLE
Merge dev to main - v0.6

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: 
       - 'main'
+      - 'dev'
     tags:
       - '*.*'
       - '*.*.*'
@@ -36,6 +37,7 @@ jobs:
             ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable=${{ endsWith(GitHub.ref, 'main') }}
+            type=raw,value=dev,enable=${{ endsWith(GitHub.ref, 'dev') }}
             type=pep440,pattern={{version}}
       - name: Build and push
         uses: docker/build-push-action@v3

--- a/README.md
+++ b/README.md
@@ -14,12 +14,16 @@ This is the hardest part, and honestly, it's not hard. Go into the Plex Web UI, 
 
 ## Create your Config File
 
-This might seem a little daunting if you've never created JSON (Javascript Object Notation) formatted text before, but it's really not so bad. You'll be a pro in no time, especially if you've ever written Python code. You'll want sections for the SPECIAL_MONTHS, HOLIDAYS, and DAILYPATH areas. Here's my config for an example:
+This might seem a little daunting if you've never created JSON (Javascript Object Notation) formatted text before, but it's really not so bad. You'll be a pro in no time, especially if you've ever written Python code. You'll want sections for the MONTHS, HOLIDAYS, and DAILYPATH areas.
+
+**NOTE**: Version 0.6 and later introduce a couple of small changes to the JSON config file. Previously, the "month" section was called SPECIAL_MONTHS and used the name of the month. As of version 0.6, the configuration now uses MONTHS as the name of the section, and uses 2-digit numbers for the month, using a leading zero for Jan - Sept.
+
+Here's my config for an example:
 
 ```json
 {
-    "SPECIAL_MONTHS": {
-        "June": "/prerolls/pride.mp4"
+    "MONTHS": {
+        "06": "/prerolls/pride.mp4"
     },
     "HOLIDAYS": {
         "0401": "/prerolls/holiday/april-fool.mp4",
@@ -31,7 +35,7 @@ This might seem a little daunting if you've never created JSON (Javascript Objec
 }
 ```
 
-Even if you're not going to do the Pride Month thing, put something in there, you can turn the feature off, I promise. More on that later when we get to the how to launch the container stuff.
+Even if you're not going to do the MONTH thing, put something in there, you can turn the feature off, I promise. More on that later when we get to the how to launch the container stuff.
 
 ## Launching the Container
 
@@ -70,4 +74,6 @@ services:
     network_mode: bridge
 ```
 
-You'll note in both of these examples, I'm leveraging many of the defaults - https, port 32400, the 3600s sync interval, leaving Pride Month activated, default location for config file, etc. That's why so few options in use.
+You'll note in both of these examples, I'm leveraging many of the defaults - https, port 32400, the 3600s sync interval, leaving the Month feature activated, default location for config file, etc. That's why so few options in use.
+
+If you'd like to deactivate the MONTHS feature, set the environment variable USE_MONTHS to 0.

--- a/prerolls.json
+++ b/prerolls.json
@@ -1,6 +1,7 @@
 {
-    "SPECIAL_MONTHS": {
-        "June": "/prerolls/pride.mp4"
+    "MONTHS": {
+        "06": "/prerolls/pride.mp4",
+        "11": "/prerolls/thanksgiving.mp4"
     },
     "HOLIDAYS": {
         "0401": "/prerolls/holiday/april-fool.mp4",

--- a/rollerblades.py
+++ b/rollerblades.py
@@ -22,7 +22,7 @@ USE_MONTHS = int(os.getenv('USE_MONTHS', 1))
 DEBUG = int(os.getenv('DEBUG', 0))
 
 # --- Globals ---
-VER = '0.5'
+VER = '0.6'
 USER_AGENT = f"rollerblades.py/{VER}"
 KEY = 'CinemaTrailersPrerollID'
 

--- a/rollerblades.py
+++ b/rollerblades.py
@@ -18,7 +18,7 @@ PORT = os.getenv('PORT', '32400')
 TOKEN = os.getenv('TOKEN')
 INTERVAL = int(os.getenv('INTERVAL', 3600))
 PREROLLS = os.getenv('PREROLLS', '/config/prerolls.json')
-PRIDEMONTH = int(os.getenv('PRIDEMONTH', 1))
+USE_MONTHS = int(os.getenv('USE_MONTHS', 1))
 DEBUG = int(os.getenv('DEBUG', 0))
 
 # --- Globals ---
@@ -79,12 +79,12 @@ def main() -> None:
         current_month = strftime("%m")
         todays_date = strftime("%m%d")
 
-        if current_month == "06" and PRIDEMONTH == 1:
-            # If it's June and you're supportive, use the pride month preroll
-            new_preroll = my_prerolls['SPECIAL_MONTHS']['June']
-        elif my_prerolls['HOLIDAYS'].get(todays_date) is not None:
+        if my_prerolls['HOLIDAYS'].get(todays_date) is not None:
             # If match on a holiday in the list of holidays, use that
             new_preroll = my_prerolls['HOLIDAYS'].get(todays_date)
+        elif USE_MONTHS == 1 and current_month in my_prerolls['MONTHS']:
+            # If current_month exists in the MONTHS section, use that.
+            new_preroll = my_prerolls['MONTHS'][current_month]
         else:
             # otherwise use the day of the week
             new_preroll = f'{my_prerolls["DAILYPATH"]}/{strftime("%A").lower()}.mp4'  # noqa E501


### PR DESCRIPTION
- change JSON from SPECIAL_MONTHS to MONTHS
- re-arrange the order in which conditions are evaluated - HOLIDAYS, MONTHS, then daily rotation. This allows for a holiday-specific preroll that's different from a month-specific preroll. For example, you could do a breast cancer-awareness preroll for October with a different one for Halloween.